### PR TITLE
Do not strip 2nd query params onwards from vanillaHash

### DIFF
--- a/src/durl.js
+++ b/src/durl.js
@@ -51,7 +51,7 @@ Durl.prototype.bootAsConsumer = function(){
 }
 
 Durl.prototype.matchDeepPath = function(path) {
-  pattern = new RegExp("(\\?|&)" + this.deep_url_var_name + "=([^&\n]*)")
+  pattern = new RegExp("(\\?|&)" + this.deep_url_var_name + "=([^\n]*)")
   return pattern.exec(this.vanillaHash()) || '' // [whole match, joiner, url]
 }
 
@@ -60,7 +60,7 @@ Durl.prototype.setDURL = function(new_url) {
   *
   * DURL will store its durl (deep url) in the consumer's hash fragment in the
   * form of `this.deep_url_var_name=url_encoded_url`
-  * 
+  *
   * But we don't know how the consumer is using their hash fragment so we try
   * to make safe, unobtrusive assumptions about how to integrate our data into
   * their fragment. Consider the following potential use cases on their end:


### PR DESCRIPTION
When vanilla hash contains a durl with query-string params, getDeepPath only retains the first one.

For example, `#durl=http://host:port/path?qs1=one&qs2=two&qs3=three` results in `#durl=http://host:port/path?qs1=one`

This change allows for the inclusion of other query-string parameters in the durl.